### PR TITLE
Add library paths for macOS

### DIFF
--- a/lib/kakasi/platform.rb
+++ b/lib/kakasi/platform.rb
@@ -31,6 +31,8 @@ module Kakasi
           case RbConfig::CONFIG['host_os']
           when /mingw|mswin/i
             []
+          when /darwin/i
+            %w[/usr/lib /usr/local/lib]
           else
             %w[/lib /usr/lib]
           end


### PR DESCRIPTION
When install kakasi on MacOS, libkakasi is created in /usr/local/lib.
Dont have permission to access /usr/lib and /lib.
Please modify it to search for libkakasi up to /usr/local/lib.